### PR TITLE
Work around an execution issue that prevented use of the PowerMock runner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,8 @@
     <logback.version>1.2.3</logback.version>
     <guava.version>28.1-android</guava.version>
     <junitparams.version>1.1.1</junitparams.version>
+    <powermock.version>2.0.9</powermock.version>
+    <mockito.version>2.28.2</mockito.version>
     <toolchains-plugin.version>1.1</toolchains-plugin.version>
     <surefire-plugin.version>2.22.0</surefire-plugin.version>
     <source-plugin.version>3.2.0</source-plugin.version>
@@ -113,6 +115,21 @@
         <artifactId>JUnitParams</artifactId>
         <version>${junitparams.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-module-junit4</artifactId>
+        <version>${powermock.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-api-mockito2</artifactId>
+        <version>${powermock.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   
@@ -154,6 +171,21 @@
     <dependency>
       <groupId>pl.pragmatists</groupId>
       <artifactId>JUnitParams</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
   
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <compile-jdk.version>1.7</compile-jdk.version>
+    <test-jdk.version>1.8</test-jdk.version>
     <java-utils.version>1.9.3</java-utils.version>
     <settings.version>2.3.3</settings.version>
     <junit.version>4.13.1</junit.version>
@@ -40,6 +40,7 @@
     <powermock.version>2.0.9</powermock.version>
     <mockito.version>2.28.2</mockito.version>
     <toolchains-plugin.version>1.1</toolchains-plugin.version>
+    <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>2.22.0</surefire-plugin.version>
     <source-plugin.version>3.2.0</source-plugin.version>
     <javadoc-plugin.version>3.1.1</javadoc-plugin.version>
@@ -195,8 +196,8 @@
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-toolchains-plugin</artifactId>
-          <version>${toolchains-plugin.version}</version>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${compiler-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -233,57 +234,30 @@
           <artifactId>maven-jar-plugin</artifactId>
           <version>${jar-plugin.version}</version>
         </plugin>
-        <plugin>
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
-          <configuration>
-            <lifecycleMappingMetadata>
-              <pluginExecutions>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-toolchains-plugin</artifactId>
-                    <versionRange>[1.0.0,)</versionRange>
-                    <goals>
-                      <goal>toolchain</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <execute />
-                  </action>
-                </pluginExecution>
-              </pluginExecutions>
-            </lifecycleMappingMetadata>
-          </configuration>
-        </plugin>
       </plugins>
     </pluginManagement>
     
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-toolchains-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>toolchain</goal>
-            </goals>
-          </execution>
-        </executions>
+        <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <toolchains>
-            <jdk>
-              <version>1.7</version>
-              <vendor>oracle</vendor>
-            </jdk>
-          </toolchains>
+          <source>${compile-jdk.version}</source>
+          <target>${compile-jdk.version}</target>
+          <jdkToolchain>
+            <version>${compile-jdk.version}</version>
+            <vendor>oracle</vendor>
+          </jdkToolchain>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <jdkToolchain>
+            <version>${test-jdk.version}</version>
+            <vendor>oracle</vendor>
+          </jdkToolchain>
           <argLine>-javaagent:src/test/resources/test-agent.jar</argLine>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
     <guava.version>28.1-android</guava.version>
     <junitparams.version>1.1.1</junitparams.version>
     <powermock.version>2.0.9</powermock.version>
-    <mockito.version>2.28.2</mockito.version>
     <toolchains-plugin.version>1.1</toolchains-plugin.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>2.22.0</surefire-plugin.version>
@@ -126,11 +125,6 @@
         <artifactId>powermock-api-mockito2</artifactId>
         <version>${powermock.version}</version>
       </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>${mockito.version}</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   
@@ -182,11 +176,6 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito2</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/nordstrom/automation/junit/LifecycleHooks.java
+++ b/src/main/java/com/nordstrom/automation/junit/LifecycleHooks.java
@@ -312,6 +312,7 @@ public class LifecycleHooks {
     /**
      * Get the atomic test object for the specified class runner.
      * 
+     * @param <T> data type of runner's children
      * @param runner JUnit class runner
      * @return {@link AtomicTest} object (may be {@code null})
      */

--- a/src/main/java/com/nordstrom/automation/junit/Run.java
+++ b/src/main/java/com/nordstrom/automation/junit/Run.java
@@ -138,7 +138,7 @@ public class Run {
      */
     static boolean fireRunStarted(Object runner) {
         if (startNotified.add(runner.toString())) {
-        	JUnitConfig.getConfig();
+            JUnitConfig.getConfig();
             List<?> grandchildren = LifecycleHooks.invoke(runner, "getChildren");
             for (Object grandchild : grandchildren) {
                 CHILD_TO_PARENT.put(grandchild, runner);

--- a/src/main/java/com/nordstrom/automation/junit/Run.java
+++ b/src/main/java/com/nordstrom/automation/junit/Run.java
@@ -138,6 +138,7 @@ public class Run {
      */
     static boolean fireRunStarted(Object runner) {
         if (startNotified.add(runner.toString())) {
+        	JUnitConfig.getConfig();
             List<?> grandchildren = LifecycleHooks.invoke(runner, "getChildren");
             for (Object grandchild : grandchildren) {
                 CHILD_TO_PARENT.put(grandchild, runner);

--- a/src/main/java/com/nordstrom/automation/junit/RunReflectiveCall.java
+++ b/src/main/java/com/nordstrom/automation/junit/RunReflectiveCall.java
@@ -159,8 +159,8 @@ public class RunReflectiveCall {
             if (0 == depthGauge.decreaseDepth()) {
                 if (LOGGER.isDebugEnabled()) {
                     try {
-						LOGGER.debug("afterInvocation: {}",
-								(Description) LifecycleHooks.invoke(runner, "describeChild", child));
+                        LOGGER.debug("afterInvocation: {}",
+                                (Description) LifecycleHooks.invoke(runner, "describeChild", child));
                     } catch (Throwable t) {
                         // nothing to do here
                     }

--- a/src/main/java/com/nordstrom/automation/junit/RunReflectiveCall.java
+++ b/src/main/java/com/nordstrom/automation/junit/RunReflectiveCall.java
@@ -10,6 +10,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.lang.IllegalAccessException;
 
 import org.junit.internal.runners.model.ReflectiveCallable;
+import org.junit.runner.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -122,7 +123,8 @@ public class RunReflectiveCall {
             if (0 == depthGauge.increaseDepth()) {
                 if (LOGGER.isDebugEnabled()) {
                     try {
-                        LOGGER.debug("beforeInvocation: {}", LifecycleHooks.invoke(runner, "describeChild", child));
+                        LOGGER.debug("beforeInvocation: {}",
+                                (Description) LifecycleHooks.invoke(runner, "describeChild", child));
                     } catch (Throwable t) {
                         // nothing to do here
                     }
@@ -156,7 +158,8 @@ public class RunReflectiveCall {
             if (0 == depthGauge.decreaseDepth()) {
                 if (LOGGER.isDebugEnabled()) {
                     try {
-                        LOGGER.debug("afterInvocation: {}", LifecycleHooks.invoke(runner, "describeChild", child));
+						LOGGER.debug("afterInvocation: {}",
+								(Description) LifecycleHooks.invoke(runner, "describeChild", child));
                     } catch (Throwable t) {
                         // nothing to do here
                     }

--- a/src/main/java/com/nordstrom/automation/junit/RunWithCompleteAssignment.java
+++ b/src/main/java/com/nordstrom/automation/junit/RunWithCompleteAssignment.java
@@ -28,7 +28,7 @@ public class RunWithCompleteAssignment {
      * <p>
      * <b>NOTE</b>: This method relies on the "theory catalyst" created by the {@link MethodBlock}
      * class to attach the class runner to the thread and create a new atomic test for the target
-     * method. The actual method block statement is retrieved from <b>MethodBlock<b> and executed,
+     * method. The actual method block statement is retrieved from <b>MethodBlock</b> and executed,
      * publishing a complete set of test lifecycle events.
      * 
      * @param anchor current {@code TheoryAnchor} statement

--- a/src/test/java/com/nordstrom/automation/junit/PowerMockCases.java
+++ b/src/test/java/com/nordstrom/automation/junit/PowerMockCases.java
@@ -17,24 +17,24 @@ import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 @PowerMockRunnerDelegate(BlockJUnit4ClassRunner.class)
 @PrepareForTest(PowerMockCases.StaticClass.class)
 public class PowerMockCases {
-	
-	@Test
-	public void testHappyPath() {
+    
+    @Test
+    public void testHappyPath() {
         mockStatic(StaticClass.class);
         when(StaticClass.staticMethod()).thenReturn("mocked");
         assertThat(StaticClass.staticMethod(), equalTo("mocked"));
-	}
-	
-	@Test
-	public void testFailure() {
+    }
+    
+    @Test
+    public void testFailure() {
         mockStatic(StaticClass.class);
         when(StaticClass.staticMethod()).thenReturn("mocked");
         assertThat(StaticClass.staticMethod(), nullValue());
-	}
+    }
 
-	static class StaticClass {
-		public static String staticMethod() {
-			return null;
-		}
-	}
+    static class StaticClass {
+        public static String staticMethod() {
+            return null;
+        }
+    }
 }

--- a/src/test/java/com/nordstrom/automation/junit/PowerMockCases.java
+++ b/src/test/java/com/nordstrom/automation/junit/PowerMockCases.java
@@ -8,10 +8,13 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(BlockJUnit4ClassRunner.class)
 @PrepareForTest(PowerMockCases.StaticClass.class)
 public class PowerMockCases {
 	

--- a/src/test/java/com/nordstrom/automation/junit/PowerMockCases.java
+++ b/src/test/java/com/nordstrom/automation/junit/PowerMockCases.java
@@ -1,0 +1,37 @@
+package com.nordstrom.automation.junit;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(PowerMockCases.StaticClass.class)
+public class PowerMockCases {
+	
+	@Test
+	public void testHappyPath() {
+        mockStatic(StaticClass.class);
+        when(StaticClass.staticMethod()).thenReturn("mocked");
+        assertThat(StaticClass.staticMethod(), equalTo("mocked"));
+	}
+	
+	@Test
+	public void testFailure() {
+        mockStatic(StaticClass.class);
+        when(StaticClass.staticMethod()).thenReturn("mocked");
+        assertThat(StaticClass.staticMethod(), nullValue());
+	}
+
+	static class StaticClass {
+		public static String staticMethod() {
+			return null;
+		}
+	}
+}

--- a/src/test/java/com/nordstrom/automation/junit/PowerMockTest.java
+++ b/src/test/java/com/nordstrom/automation/junit/PowerMockTest.java
@@ -1,0 +1,26 @@
+package com.nordstrom.automation.junit;
+
+import static org.junit.Assert.assertFalse;
+import static org.testng.Assert.assertEquals;
+
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.testng.annotations.Test;
+
+public class PowerMockTest {
+
+    @Test
+    public void verifyMethodInterception() {
+        RunListenerAdapter rla = new RunListenerAdapter();
+
+        JUnitCore runner = new JUnitCore();
+        runner.addListener(rla);
+        Result result = runner.run(PowerMockCases.class);
+        assertFalse(result.wasSuccessful());
+        
+        assertEquals(rla.getPassedTests().size(), 1, "Incorrect passed test count");
+        assertEquals(rla.getFailedTests().size(), 1, "Incorrect failed test count");
+        assertEquals(rla.getIgnoredTests().size(), 0, "Incorrect ignored test count");
+    }
+
+}

--- a/src/test/java/com/nordstrom/automation/junit/PowerMockTest.java
+++ b/src/test/java/com/nordstrom/automation/junit/PowerMockTest.java
@@ -19,8 +19,8 @@ public class PowerMockTest {
         assertFalse(result.wasSuccessful());
         
         assertEquals(rla.getPassedTests().size(), 1, "Incorrect passed test count");
-		assertEquals(rla.getPassedTests().get(0).getDisplayName(),
-				"testHappyPath(com.nordstrom.automation.junit.PowerMockCases)", "Incorrect passed test name");
+        assertEquals(rla.getPassedTests().get(0).getDisplayName(),
+                "testHappyPath(com.nordstrom.automation.junit.PowerMockCases)", "Incorrect passed test name");
         assertEquals(rla.getFailedTests().size(), 1, "Incorrect failed test count");
         assertEquals(rla.getIgnoredTests().size(), 0, "Incorrect ignored test count");
     }

--- a/src/test/java/com/nordstrom/automation/junit/PowerMockTest.java
+++ b/src/test/java/com/nordstrom/automation/junit/PowerMockTest.java
@@ -19,6 +19,8 @@ public class PowerMockTest {
         assertFalse(result.wasSuccessful());
         
         assertEquals(rla.getPassedTests().size(), 1, "Incorrect passed test count");
+		assertEquals(rla.getPassedTests().get(0).getDisplayName(),
+				"testHappyPath(com.nordstrom.automation.junit.PowerMockCases)", "Incorrect passed test name");
         assertEquals(rla.getFailedTests().size(), 1, "Incorrect failed test count");
         assertEquals(rla.getIgnoredTests().size(), 0, "Incorrect ignored test count");
     }


### PR DESCRIPTION
Resolves #77 
Once activated, **PowerMock** apparently wants to proxy everything. One side effect of this proclivity is that it can subtly alter objects in obscure parts of the implementation, far removed from any intended code. This can cause anomalous behavior, like the object-type mismatch that occurred deep in the bowels of **Apache Commons Configuration**.

To avoid the object-type mismatch, I now instantiate the configuration object in the interceptor for the `run` method, prior to the execution of **PowerMockRunner**.

These revisions include **PowerMock** unit tests. The **JUnit Foundation** library is targeted at Java 7, but **Mockito** requires Java 8, so I updated the project to compile for Java 7 and execute tests in Java 8. This effort was very useful, because figuring out how to get this to work revealed that I didn't need the `maven-toolchain-plugin`, the removal of which allowed me to eliminate the **Eclipse** `lifecycle-mapping` plugin.